### PR TITLE
Consistent line breaks between webpage & CSV

### DIFF
--- a/templates/results/index.html
+++ b/templates/results/index.html
@@ -84,7 +84,7 @@
 									<td>
 										<div class="item_content">
 											{% if report.allowHtml %}
-												{{ property|raw }}
+												{{ property|nl2br|raw }}
 											{% else %}
 												{{ property }}
 											{% endif %}

--- a/templates/results/index.html
+++ b/templates/results/index.html
@@ -84,7 +84,7 @@
 									<td>
 										<div class="item_content">
 											{% if report.allowHtml %}
-												{{ property|nl2br|raw }}
+												{{ property|raw|nl2br }}
 											{% else %}
 												{{ property }}
 											{% endif %}


### PR DESCRIPTION
This change will allow the user to output `\n` as line breaks, and have the breaks appear equally in both the CSV and online version of the table.

As noted in this issue for Sprout Reports...

https://github.com/barrelstrength/craft-sprout-reports/issues/26

This PR addresses the issue in Craft 2.